### PR TITLE
Fix all schema URIs for v1.0.1 release

### DIFF
--- a/examples/multidataset/spacenet-buildings/AOI_2_Vegas_img2636.json
+++ b/examples/multidataset/spacenet-buildings/AOI_2_Vegas_img2636.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0-rc.1",
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json",
     "https://stac-extensions.github.io/version/v1.0.0/schema.json"
   ],
   "id": "AOI_2_Vegas_img2636",

--- a/examples/multidataset/spacenet-buildings/AOI_3_Paris_img1648.json
+++ b/examples/multidataset/spacenet-buildings/AOI_3_Paris_img1648.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0-rc.1",
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json",
     "https://stac-extensions.github.io/version/v1.0.0/schema.json"
   ],
   "id": "AOI_3_Paris_img1648",

--- a/examples/multidataset/spacenet-buildings/AOI_4_Shanghai_img3344.json
+++ b/examples/multidataset/spacenet-buildings/AOI_4_Shanghai_img3344.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0-rc.1",
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json",
     "https://stac-extensions.github.io/version/v1.0.0/schema.json"
   ],
   "id": "AOI_4_Shanghai_img3344",

--- a/examples/multidataset/zanzibar/znz001.json
+++ b/examples/multidataset/zanzibar/znz001.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0-rc.1",
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json",
     "https://stac-extensions.github.io/version/v1.0.0/schema.json"
   ],
   "id": "znz001",

--- a/examples/spacenet-roads/roads_item.json
+++ b/examples/spacenet-roads/roads_item.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0-rc.1",
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json",
     "https://stac-extensions.github.io/version/v1.0.0/schema.json"
   ],
   "id": "AOI_3_Paris_img101",

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://stac-extensions.github.io/label/v1.0.0/schema.json#",
+  "$id": "https://stac-extensions.github.io/label/v1.0.1/schema.json#",
   "title": "Label Extension",
   "description": "STAC Label Extension for STAC Items and STAC Collections.",
   "oneOf": [
@@ -95,7 +95,7 @@
         "stac_extensions": {
           "type": "array",
           "contains": {
-            "const": "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+            "const": "https://stac-extensions.github.io/label/v1.0.1/schema.json"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "scripts": {
     "test": "npm run check-markdown && npm run check-examples",
     "check-markdown": "remark . -f -r .github/remark.yaml",
-    "check-examples": "stac-node-validator . --lint --verbose --schemaMap https://stac-extensions.github.io/label/v1.0.0/schema.json=./json-schema/schema.json",
-    "format-examples": "stac-node-validator . --format --schemaMap https://stac-extensions.github.io/label/v1.0.0/schema.json=./json-schema/schema.json"
+    "check-examples": "stac-node-validator . --lint --verbose --schemaMap https://stac-extensions.github.io/label/v1.0.1/schema.json=./json-schema/schema.json",
+    "format-examples": "stac-node-validator . --format --schemaMap https://stac-extensions.github.io/label/v1.0.1/schema.json=./json-schema/schema.json"
   },
   "dependencies": {
     "remark-cli": "^8.0.0",


### PR DESCRIPTION
The JSON schema for the v1.0.1 release still had references to the old schema URI (v1.0.0) as did the examples and the `package.json` commands. This PR updates all files to use the new schema URI.

@m-mohr I will update the v1.0.1 tag and re-publish the release once this is merged.